### PR TITLE
Drop deprecated parameters from attr.s decorator

### DIFF
--- a/dephell_markers/_marker/_base.py
+++ b/dephell_markers/_marker/_base.py
@@ -8,7 +8,7 @@ from .._cached_property import cached_property
 from .._constants import ALIASES
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False, order=False)
 class BaseMarker:
     lhs = attr.ib()
     op = attr.ib()


### PR DESCRIPTION
`cmp` is deprecated and going to be removed after 2021-06-01,
replace it with `eq` and `order`.

Fixes #2